### PR TITLE
Fixed filename parsing error

### DIFF
--- a/source/jamstub.c
+++ b/source/jamstub.c
@@ -1025,11 +1025,7 @@ int main(int argc, char **argv)
 
 	for (arg = 1; arg < argc; arg++)
 	{
-#if PORT == UNIX
 		if (argv[arg][0] == '-')
-#else
-		if ((argv[arg][0] == '-') || (argv[arg][0] == '/'))
-#endif
 		{
 			switch(toupper(argv[arg][1]))
 			{


### PR DESCRIPTION
Error occurs when filename starts with "/" on Linux.